### PR TITLE
feat(sim): publish UR5e force/torque via Ignition + ros2_control + bridge

### DIFF
--- a/src/ur_description/urdf/ur.ros2_control.xacro
+++ b/src/ur_description/urdf/ur.ros2_control.xacro
@@ -127,15 +127,23 @@
         <state_interface name="effort"/>
       </joint>
 
+      <sensor name="${tf_prefix}tcp_fts_sensor">
+        <state_interface name="force.x"/>
+        <state_interface name="force.y"/>
+        <state_interface name="force.z"/>
+        <state_interface name="torque.x"/>
+        <state_interface name="torque.y"/>
+        <state_interface name="torque.z"/>
+      </sensor>
       <xacro:unless value="${sim_gazebo or sim_ignition}">
-        <sensor name="${tf_prefix}tcp_fts_sensor">
+        <!-- <sensor name="${tf_prefix}tcp_fts_sensor">
           <state_interface name="force.x"/>
           <state_interface name="force.y"/>
           <state_interface name="force.z"/>
           <state_interface name="torque.x"/>
           <state_interface name="torque.y"/>
           <state_interface name="torque.z"/>
-        </sensor>
+        </sensor> -->
 
         <sensor name="${tf_prefix}tcp_pose">
           <state_interface name="position.x"/>

--- a/src/ur_description/urdf/ur_macro.xacro
+++ b/src/ur_description/urdf/ur_macro.xacro
@@ -437,6 +437,19 @@
       <origin xyz="0 0 0" rpy="${pi} 0 0"/>
     </joint>
 
+
+    <!-- Ignition Gazebo F/T sensor -->
+    <gazebo reference="${tf_prefix}wrist_3_joint">
+      <sensor name="tcp_ft_sensor" type="force_torque">
+        <always_on>true</always_on>
+        <update_rate>100</update_rate>
+        <force_torque>
+          <frame>sensor</frame>
+          <measure_direction>child_to_parent</measure_direction>
+        </force_torque>
+      </sensor>        
+    </gazebo>
+      
     <!-- ROS-Industrial 'base' frame - base_link to UR 'Base' Coordinates transform -->
     <link name="${tf_prefix}base"/>
     <joint name="${tf_prefix}base_link-base_fixed_joint" type="fixed">

--- a/src/ur_simulation_gz/ur_simulation_gz/CMakeLists.txt
+++ b/src/ur_simulation_gz/ur_simulation_gz/CMakeLists.txt
@@ -10,7 +10,7 @@ option(
   OFF
 )
 
-install(DIRECTORY config launch
+install(DIRECTORY config launch world
   DESTINATION share/${PROJECT_NAME}
 )
 

--- a/src/ur_simulation_gz/ur_simulation_gz/config/ur_controllers.yaml
+++ b/src/ur_simulation_gz/ur_simulation_gz/config/ur_controllers.yaml
@@ -23,7 +23,22 @@ controller_manager:
     forward_position_controller:
       type: position_controllers/JointGroupPositionController
 
+    force_torque_sensor_broadcaster:
+      type: force_torque_sensor_broadcaster/ForceTorqueSensorBroadcaster
 
+
+force_torque_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: tcp_ft_sensor
+    state_interface_names:
+      - tcp_ft_sensor/force.x
+      - tcp_ft_sensor/force.y
+      - tcp_ft_sensor/force.z
+      - tcp_ft_sensor/torque.x
+      - tcp_ft_sensor/torque.y
+      - tcp_ft_sensor/torque.z
+    frame_id: ft_frame
+    
 speed_scaling_state_broadcaster:
   ros__parameters:
     state_publish_rate: 100.0

--- a/src/ur_simulation_gz/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/src/ur_simulation_gz/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -189,6 +189,12 @@ def launch_setup(context, *args, **kwargs):
         executable="parameter_bridge",
         arguments=[
             "/clock@rosgraph_msgs/msg/Clock[ignition.msgs.Clock",
+             "/world/empty/model/ur/joint/wrist_3_joint/sensor/tcp_ft_sensor/forcetorque@geometry_msg\
+s/msg/WrenchStamped[ignition.msgs.Wrench",
+        ],
+        remappings=[
+        ("/world/empty/model/ur/joint/wrist_3_joint/sensor/tcp_ft_sensor/forcetorque",
+         "/tcp_ft_sensor/wrench")
         ],
         output="screen",
     )
@@ -315,11 +321,25 @@ def generate_launch_description():
             "gazebo_gui", default_value="true", description="Start gazebo with GUI?"
         )
     )
+
+    # declared_arguments.append(
+    #     DeclareLaunchArgument(
+    #         "world_file",
+    #         default_value="empty_with_ft.sdf",
+    #         description="Gazebo world file (absolute path or filename from the gazebosim worlds collection) containing a custom world.",
+    #     )
+    # )
+
     declared_arguments.append(
         DeclareLaunchArgument(
             "world_file",
-            default_value="empty.sdf",
-            description="Gazebo world file (absolute path or filename from the gazebosim worlds collection) containing a custom world.",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("ur_simulation_gz"), "world", "empty_with_ft.sdf"]
+            ),
+            description=(
+                "Gazebo world file. Defaults to the package-local worlds/empty_with_ft.sdf. "
+                "You may override with an absolute path or another file."
+            ),
         )
     )
 

--- a/src/ur_simulation_gz/ur_simulation_gz/world/empty_ft.sdf
+++ b/src/ur_simulation_gz/ur_simulation_gz/world/empty_ft.sdf
@@ -1,0 +1,70 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="empty">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-contact-system"
+      name="gz::sim::systems::Contact">
+    </plugin>
+    <plugin filename="ignition-gazebo-forcetorque-system" name="ignition::gazebo::systems::ForceTorque"/>
+    <plugin filename="ignition-gazebo-sensors-system" name="ignition::gazebo::systems::Sensors"/>
+    <plugin filename="gz_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin"/>
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>

--- a/src/ur_simulation_gz/ur_simulation_gz/world/empty_with_ft.sdf
+++ b/src/ur_simulation_gz/ur_simulation_gz/world/empty_with_ft.sdf
@@ -1,0 +1,82 @@
+<?xml version="1.0" ?>
+<sdf version="1.6">
+  <world name="empty">
+    <physics name="1ms" type="ignored">
+      <max_step_size>0.001</max_step_size>
+      <real_time_factor>1.0</real_time_factor>
+    </physics>
+    <plugin
+      filename="ignition-gazebo-physics-system"
+      name="gz::sim::systems::Physics">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-user-commands-system"
+      name="gz::sim::systems::UserCommands">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-scene-broadcaster-system"
+      name="gz::sim::systems::SceneBroadcaster">
+    </plugin>
+    <plugin
+      filename="ignition-gazebo-contact-system"
+      name="gz::sim::systems::Contact">
+    </plugin>
+    <plugin
+	filename="ignition-gazebo-forcetorque-system"
+	name="ignition::gazebo::systems::ForceTorque">
+    </plugin>
+    <plugin
+	filename="ignition-gazebo-sensors-system"
+	name="ignition::gazebo::systems::Sensors"/>
+    <!-- <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin"> -->
+    <!-- </plugin> -->
+    <!-- <plugin -->
+    <!-- 	filename="libign_ros2_control-system.so" -->
+    <!-- 	name="gz_ros2_control::GazeboSimROS2ControlPlugin"/> -->
+   <!-- <plugin filename="gz_ros2_control-system" -->
+   <!--      name="gz_ros2_control::GazeboSimROS2ControlPlugin"/> -->
+
+
+    <light type="directional" name="sun">
+      <cast_shadows>true</cast_shadows>
+      <pose>0 0 10 0 0 0</pose>
+      <diffuse>0.8 0.8 0.8 1</diffuse>
+      <specular>0.2 0.2 0.2 1</specular>
+      <attenuation>
+        <range>1000</range>
+        <constant>0.9</constant>
+        <linear>0.01</linear>
+        <quadratic>0.001</quadratic>
+      </attenuation>
+      <direction>-0.5 0.1 -0.9</direction>
+    </light>
+
+    <model name="ground_plane">
+      <static>true</static>
+      <link name="link">
+        <collision name="collision">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+        </collision>
+        <visual name="visual">
+          <geometry>
+            <plane>
+              <normal>0 0 1</normal>
+              <size>100 100</size>
+            </plane>
+          </geometry>
+          <material>
+            <ambient>0.8 0.8 0.8 1</ambient>
+            <diffuse>0.8 0.8 0.8 1</diffuse>
+            <specular>0.8 0.8 0.8 1</specular>
+          </material>
+        </visual>
+      </link>
+    </model>
+
+  </world>
+</sdf>


### PR DESCRIPTION
# Summary
- Add FT sensor (`tcp_ft_sensor`) on `wrist_3_joint`
- Expose sensor state interfaces in `ros2_control`
- Configure `force_torque_sensor_broadcaster`
- Add Gazebo world plugins (sensors, forcetorque, ros2_control)
- Launch file spawner + ROS–GZ bridge for Wrench topic

# Changes
- `src/ur_description/urdf/ur_macro.xacro`  
  - Added `<gazebo><sensor type="force_torque">` under `wrist_3_joint`
- `src/ur_description/urdf/ur.ros2_control.xacro`  
  - Added `tcp_ft_sensor` state interfaces (force/torque)
- `src/ur_simulation_gz/config/ur_controllers.yaml`  
  - Configured `force_torque_sensor_broadcaster`
- `src/ur_simulation_gz/worlds/empty_with_ft.sdf`  
  - Added Gazebo plugins (`sensors`, `forcetorque`, `ign_ros2_control`)
- `src/ur_simulation_gz/launch/ur_sim_control.launch.py`  
  - Spawner for FT broadcaster  
  - Parameter bridge for `/tcp_ft_sensor/forcetorque`

# How to test
\`\`\`bash
rm -rf build install log
colcon build
source install/setup.bash

ros2 launch ur_simulation_gz ur_sim_control.launch.py gazebo_gui:=true

ros2 topic list | grep wrench
ros2 topic echo /tcp_ft_sensor/forcetorque
\`\`\`

# Notes
- `frame_id`: `ft_frame`
- Topic name may be remapped to `/ur5e/ft_wrench` if desired
- Requires `ros-humble-ros-gz-bridge`, `ros-humble-force-torque-sensor-broadcaster`

# Checklist
- [ ] Builds locally (`colcon build`)
- [ ] Simulation runs without errors
- [ ] Wrench data published on expected topic
- [ ] README updated with FT sensor setup
